### PR TITLE
[#20] refactor: useReducer + RTK combination

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -31,6 +31,7 @@ const RAW_RUNTIME_STATE =
           ["@reduxjs/toolkit", "virtual:fab99ab653819c31700118e3551051ec2498dddb808f51896150d7d12ac371c264b5fa46a662ab7fea4ee02c7e8cf37d0e46b047c0fd340fb8234dee7ca27815#npm:2.3.0"],\
           ["@tanstack/react-query", "virtual:fab99ab653819c31700118e3551051ec2498dddb808f51896150d7d12ac371c264b5fa46a662ab7fea4ee02c7e8cf37d0e46b047c0fd340fb8234dee7ca27815#npm:5.56.2"],\
           ["@types/node", "npm:20.16.5"],\
+          ["@types/numeral", "npm:2.0.5"],\
           ["@types/prop-types", "npm:15.7.13"],\
           ["@types/react", "npm:18.3.5"],\
           ["@types/react-dom", "npm:18.3.0"],\
@@ -45,6 +46,7 @@ const RAW_RUNTIME_STATE =
           ["msw", "virtual:fab99ab653819c31700118e3551051ec2498dddb808f51896150d7d12ac371c264b5fa46a662ab7fea4ee02c7e8cf37d0e46b047c0fd340fb8234dee7ca27815#npm:2.4.9"],\
           ["next", "virtual:fab99ab653819c31700118e3551051ec2498dddb808f51896150d7d12ac371c264b5fa46a662ab7fea4ee02c7e8cf37d0e46b047c0fd340fb8234dee7ca27815#npm:14.2.9"],\
           ["next-auth", "virtual:fab99ab653819c31700118e3551051ec2498dddb808f51896150d7d12ac371c264b5fa46a662ab7fea4ee02c7e8cf37d0e46b047c0fd340fb8234dee7ca27815#npm:4.24.7"],\
+          ["numeral", "npm:2.0.6"],\
           ["postcss", "npm:8.4.45"],\
           ["prettier", "npm:3.3.3"],\
           ["prop-types", "npm:15.8.1"],\
@@ -740,6 +742,15 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@types/node", "npm:22.7.4"],\
           ["undici-types", "npm:6.19.8"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@types/numeral", [\
+      ["npm:2.0.5", {\
+        "packageLocation": "../../../../.yarn/berry/cache/@types-numeral-npm-2.0.5-5ee1a717c4-10c0.zip/node_modules/@types/numeral/",\
+        "packageDependencies": [\
+          ["@types/numeral", "npm:2.0.5"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -1912,6 +1923,7 @@ const RAW_RUNTIME_STATE =
           ["@reduxjs/toolkit", "virtual:fab99ab653819c31700118e3551051ec2498dddb808f51896150d7d12ac371c264b5fa46a662ab7fea4ee02c7e8cf37d0e46b047c0fd340fb8234dee7ca27815#npm:2.3.0"],\
           ["@tanstack/react-query", "virtual:fab99ab653819c31700118e3551051ec2498dddb808f51896150d7d12ac371c264b5fa46a662ab7fea4ee02c7e8cf37d0e46b047c0fd340fb8234dee7ca27815#npm:5.56.2"],\
           ["@types/node", "npm:20.16.5"],\
+          ["@types/numeral", "npm:2.0.5"],\
           ["@types/prop-types", "npm:15.7.13"],\
           ["@types/react", "npm:18.3.5"],\
           ["@types/react-dom", "npm:18.3.0"],\
@@ -1926,6 +1938,7 @@ const RAW_RUNTIME_STATE =
           ["msw", "virtual:fab99ab653819c31700118e3551051ec2498dddb808f51896150d7d12ac371c264b5fa46a662ab7fea4ee02c7e8cf37d0e46b047c0fd340fb8234dee7ca27815#npm:2.4.9"],\
           ["next", "virtual:fab99ab653819c31700118e3551051ec2498dddb808f51896150d7d12ac371c264b5fa46a662ab7fea4ee02c7e8cf37d0e46b047c0fd340fb8234dee7ca27815#npm:14.2.9"],\
           ["next-auth", "virtual:fab99ab653819c31700118e3551051ec2498dddb808f51896150d7d12ac371c264b5fa46a662ab7fea4ee02c7e8cf37d0e46b047c0fd340fb8234dee7ca27815#npm:4.24.7"],\
+          ["numeral", "npm:2.0.6"],\
           ["postcss", "npm:8.4.45"],\
           ["prettier", "npm:3.3.3"],\
           ["prop-types", "npm:15.8.1"],\
@@ -4195,6 +4208,15 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "../../../../.yarn/berry/cache/normalize-path-npm-3.0.0-658ba7d77f-10c0.zip/node_modules/normalize-path/",\
         "packageDependencies": [\
           ["normalize-path", "npm:3.0.0"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["numeral", [\
+      ["npm:2.0.6", {\
+        "packageLocation": "../../../../.yarn/berry/cache/numeral-npm-2.0.6-2c27ceaa3c-10c0.zip/node_modules/numeral/",\
+        "packageDependencies": [\
+          ["numeral", "npm:2.0.6"]\
         ],\
         "linkType": "HARD"\
       }]\

--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -28,6 +28,7 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./",\
         "packageDependencies": [\
           ["@hookform/resolvers", "virtual:fab99ab653819c31700118e3551051ec2498dddb808f51896150d7d12ac371c264b5fa46a662ab7fea4ee02c7e8cf37d0e46b047c0fd340fb8234dee7ca27815#npm:3.9.0"],\
+          ["@reduxjs/toolkit", "virtual:fab99ab653819c31700118e3551051ec2498dddb808f51896150d7d12ac371c264b5fa46a662ab7fea4ee02c7e8cf37d0e46b047c0fd340fb8234dee7ca27815#npm:2.3.0"],\
           ["@tanstack/react-query", "virtual:fab99ab653819c31700118e3551051ec2498dddb808f51896150d7d12ac371c264b5fa46a662ab7fea4ee02c7e8cf37d0e46b047c0fd340fb8234dee7ca27815#npm:5.56.2"],\
           ["@types/node", "npm:20.16.5"],\
           ["@types/prop-types", "npm:15.7.13"],\
@@ -584,6 +585,36 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "../../../../.yarn/berry/cache/@pkgr-core-npm-0.1.1-844d1f59d1-10c0.zip/node_modules/@pkgr/core/",\
         "packageDependencies": [\
           ["@pkgr/core", "npm:0.1.1"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@reduxjs/toolkit", [\
+      ["npm:2.3.0", {\
+        "packageLocation": "../../../../.yarn/berry/cache/@reduxjs-toolkit-npm-2.3.0-ef088f27ef-10c0.zip/node_modules/@reduxjs/toolkit/",\
+        "packageDependencies": [\
+          ["@reduxjs/toolkit", "npm:2.3.0"]\
+        ],\
+        "linkType": "SOFT"\
+      }],\
+      ["virtual:fab99ab653819c31700118e3551051ec2498dddb808f51896150d7d12ac371c264b5fa46a662ab7fea4ee02c7e8cf37d0e46b047c0fd340fb8234dee7ca27815#npm:2.3.0", {\
+        "packageLocation": "./.yarn/__virtual__/@reduxjs-toolkit-virtual-746161afca/5/.yarn/berry/cache/@reduxjs-toolkit-npm-2.3.0-ef088f27ef-10c0.zip/node_modules/@reduxjs/toolkit/",\
+        "packageDependencies": [\
+          ["@reduxjs/toolkit", "virtual:fab99ab653819c31700118e3551051ec2498dddb808f51896150d7d12ac371c264b5fa46a662ab7fea4ee02c7e8cf37d0e46b047c0fd340fb8234dee7ca27815#npm:2.3.0"],\
+          ["@types/react", "npm:18.3.5"],\
+          ["@types/react-redux", null],\
+          ["immer", "npm:10.1.1"],\
+          ["react", "npm:18.3.1"],\
+          ["react-redux", null],\
+          ["redux", "npm:5.0.1"],\
+          ["redux-thunk", "virtual:746161afca8a6fa59dd93c3aa9c1bac7171a856c7cc92ef38712dd56c9bc293bb7d8822398fc41e05af3038e5cbaf032839c35c7b1521803eafb66f44bee20a7#npm:3.1.0"],\
+          ["reselect", "npm:5.1.1"]\
+        ],\
+        "packagePeers": [\
+          "@types/react-redux",\
+          "@types/react",\
+          "react-redux",\
+          "react"\
         ],\
         "linkType": "HARD"\
       }]\
@@ -1878,6 +1909,7 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["eqcm", "workspace:."],\
           ["@hookform/resolvers", "virtual:fab99ab653819c31700118e3551051ec2498dddb808f51896150d7d12ac371c264b5fa46a662ab7fea4ee02c7e8cf37d0e46b047c0fd340fb8234dee7ca27815#npm:3.9.0"],\
+          ["@reduxjs/toolkit", "virtual:fab99ab653819c31700118e3551051ec2498dddb808f51896150d7d12ac371c264b5fa46a662ab7fea4ee02c7e8cf37d0e46b047c0fd340fb8234dee7ca27815#npm:2.3.0"],\
           ["@tanstack/react-query", "virtual:fab99ab653819c31700118e3551051ec2498dddb808f51896150d7d12ac371c264b5fa46a662ab7fea4ee02c7e8cf37d0e46b047c0fd340fb8234dee7ca27815#npm:5.56.2"],\
           ["@types/node", "npm:20.16.5"],\
           ["@types/prop-types", "npm:15.7.13"],\
@@ -4879,6 +4911,37 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
+    ["redux", [\
+      ["npm:5.0.1", {\
+        "packageLocation": "../../../../.yarn/berry/cache/redux-npm-5.0.1-f8e6b1cb23-10c0.zip/node_modules/redux/",\
+        "packageDependencies": [\
+          ["redux", "npm:5.0.1"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["redux-thunk", [\
+      ["npm:3.1.0", {\
+        "packageLocation": "../../../../.yarn/berry/cache/redux-thunk-npm-3.1.0-6a8fdd3211-10c0.zip/node_modules/redux-thunk/",\
+        "packageDependencies": [\
+          ["redux-thunk", "npm:3.1.0"]\
+        ],\
+        "linkType": "SOFT"\
+      }],\
+      ["virtual:746161afca8a6fa59dd93c3aa9c1bac7171a856c7cc92ef38712dd56c9bc293bb7d8822398fc41e05af3038e5cbaf032839c35c7b1521803eafb66f44bee20a7#npm:3.1.0", {\
+        "packageLocation": "./.yarn/__virtual__/redux-thunk-virtual-66e1e50df0/5/.yarn/berry/cache/redux-thunk-npm-3.1.0-6a8fdd3211-10c0.zip/node_modules/redux-thunk/",\
+        "packageDependencies": [\
+          ["redux-thunk", "virtual:746161afca8a6fa59dd93c3aa9c1bac7171a856c7cc92ef38712dd56c9bc293bb7d8822398fc41e05af3038e5cbaf032839c35c7b1521803eafb66f44bee20a7#npm:3.1.0"],\
+          ["@types/redux", null],\
+          ["redux", "npm:5.0.1"]\
+        ],\
+        "packagePeers": [\
+          "@types/redux",\
+          "redux"\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
     ["reflect.getprototypeof", [\
       ["npm:1.0.6", {\
         "packageLocation": "../../../../.yarn/berry/cache/reflect.getprototypeof-npm-1.0.6-b33819c756-10c0.zip/node_modules/reflect.getprototypeof/",\
@@ -4931,6 +4994,15 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "../../../../.yarn/berry/cache/requires-port-npm-1.0.0-fd036b488a-10c0.zip/node_modules/requires-port/",\
         "packageDependencies": [\
           ["requires-port", "npm:1.0.0"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["reselect", [\
+      ["npm:5.1.1", {\
+        "packageLocation": "../../../../.yarn/berry/cache/reselect-npm-5.1.1-667568f51c-10c0.zip/node_modules/reselect/",\
+        "packageDependencies": [\
+          ["reselect", "npm:5.1.1"]\
         ],\
         "linkType": "HARD"\
       }]\

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "immer": "^10.1.1",
     "next": "14.2.9",
     "next-auth": "^4.24.7",
+    "numeral": "^2.0.6",
     "prop-types": "^15.8.1",
     "react": "^18",
     "react-dom": "^18",
@@ -26,6 +27,7 @@
   },
   "devDependencies": {
     "@types/node": "^20",
+    "@types/numeral": "^2",
     "@types/prop-types": "^15",
     "@types/react": "^18",
     "@types/react-dom": "^18",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
+    "@reduxjs/toolkit": "^2.3.0",
     "@tanstack/react-query": "^5.56.2",
     "classnames": "^2.5.1",
     "immer": "^10.1.1",

--- a/src/components/product/productOptions.tsx
+++ b/src/components/product/productOptions.tsx
@@ -1,8 +1,10 @@
-import React, { memo, useReducer } from 'react';
+import React, { memo, useEffect, useReducer, useState } from 'react';
+import { PayloadAction } from '@reduxjs/toolkit';
 import cn from 'classnames';
 import OptionDropdown from './optionDropdown';
 import OptionStepper from './optionStepper';
 import Skeleton from '../common/skeleton';
+import { useProductOptionsReducer } from '@/store/useProductOptionsReducer';
 import { formatWithCommas } from '@/utils/format';
 import { ProductDataType, ProductOptionType } from '@/types/product';
 import { Icons } from '../icons';
@@ -12,157 +14,27 @@ type Props = {
   options: ProductDataType['productInfo']['options'];
 };
 
-enum ProductActionType {
-  SELECT_OPTION = 'SELECT_OPTION',
-  CHANGE_COUNT = 'CHANGE_COUNT',
-  DELETE_OPTION = 'DELETE_OPTION',
-}
-
 export type PayloadType = {
-  optionType?: keyof ProductOptionType;
+  optionType?: string;
   value?: string | number;
   index?: number;
   count?: number;
 };
 
-let defaultOptions: ProductOptionType = {};
-
 const ProductOptions = ({ price, options }: Props) => {
-  const init = (productOptions: ProductDataType['productInfo']['options']) => {
-    const initialOptions: ProductOptionType = {};
+  const { getInitialState, reducer, actions } = useProductOptionsReducer;
+  const [state, dispatch] = useReducer(reducer, getInitialState());
+  const [totalPrice, setTotalPrice] = useState(0);
 
-    Object.keys(productOptions).forEach((optionKey) => {
-      initialOptions[optionKey] = null;
-    });
-
-    defaultOptions = initialOptions;
-
-    return {
-      currentOption: initialOptions,
-      selectedOptions: [],
-      totalPrice: 0,
+  const dispatchWithAction =
+    (actionCreator: (payload: PayloadType) => PayloadAction<PayloadType>) =>
+    (payload: PayloadType) => {
+      dispatch(actionCreator(payload));
     };
-  };
 
-  const updateTotalPrice = (options: ProductOptionType[]) => {
-    return options.reduce((total, option) => {
-      if (typeof option.count === 'number') {
-        return total + (price * option.count || 0);
-      }
-      return total;
-    }, 0);
-  };
-
-  const reducer = (
-    state,
-    action: {
-      type: ProductActionType;
-      payload: PayloadType;
-    },
-  ) => {
-    switch (action.type) {
-      case ProductActionType.SELECT_OPTION: {
-        if (!action.payload.optionType) return state;
-
-        const updatedCurrentOption = {
-          ...state.currentOption,
-          [action.payload.optionType]: action.payload.value,
-        };
-
-        const isOptionComplete = Object.values(updatedCurrentOption).every(
-          (option) => option !== null,
-        );
-        if (!isOptionComplete) {
-          return {
-            ...state,
-            currentOption: updatedCurrentOption,
-          };
-        }
-
-        const existingOptionIndex = state.selectedOptions.findIndex(
-          (option: ProductOptionType) => {
-            return Object.keys(updatedCurrentOption).every(
-              (key) => updatedCurrentOption[key] === option[key],
-            );
-          },
-        );
-
-        if (existingOptionIndex !== -1) {
-          const updatedOptions = state.selectedOptions.map(
-            (option: ProductOptionType, index: number) => {
-              if (
-                index === existingOptionIndex &&
-                typeof option.count === 'number'
-              ) {
-                return { ...option, count: option.count + 1 };
-              }
-              return option;
-            },
-          );
-
-          return {
-            ...state,
-            selectedOptions: updatedOptions,
-            totalPrice: updateTotalPrice(updatedOptions),
-          };
-        }
-
-        const updatedSelectedOptions = [
-          ...state.selectedOptions,
-          { ...updatedCurrentOption, count: 1 },
-        ];
-
-        return {
-          ...state,
-          currentOption: defaultOptions,
-          selectedOptions: updatedSelectedOptions,
-          totalPrice: updateTotalPrice(updatedSelectedOptions),
-        };
-      }
-
-      case ProductActionType.CHANGE_COUNT: {
-        const updatedOptions = state.selectedOptions.map(
-          (option: ProductOptionType, index: number) => {
-            if (index === action.payload.index) {
-              return { ...option, count: action.payload.count };
-            }
-            return option;
-          },
-        ) as ProductOptionType[];
-
-        return {
-          ...state,
-          selectedOptions: updatedOptions,
-          totalPrice: updateTotalPrice(updatedOptions),
-        };
-      }
-
-      case ProductActionType.DELETE_OPTION: {
-        const updatedOptions = state.selectedOptions.filter(
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          (_: any, index: number) => index !== action.payload.index,
-        );
-
-        return {
-          ...state,
-          selectedOptions: updatedOptions,
-          totalPrice: updateTotalPrice(updatedOptions),
-        };
-      }
-
-      default:
-        return state;
-    }
-  };
-
-  const [state, dispatch] = useReducer(reducer, init(options));
-
-  const attachType = (type: ProductActionType) => (payload: PayloadType) => {
-    dispatch({ type, payload });
-  };
-
-  const onClickOption = attachType(ProductActionType.SELECT_OPTION);
-  const onChangeCount = attachType(ProductActionType.CHANGE_COUNT);
+  const onClickOption = dispatchWithAction(actions.selectOption);
+  const onChangeCount = dispatchWithAction(actions.changeCount);
+  const onClickDelete = dispatchWithAction(actions.deleteOption);
 
   const makeOptionName = (option: ProductOptionType) => {
     const divide = ' - ';
@@ -174,6 +46,28 @@ const ProductOptions = ({ price, options }: Props) => {
       .join(divide);
   };
 
+  useEffect(() => {
+    const initialOptions: ProductOptionType = {};
+
+    Object.keys(options).forEach((optionKey) => {
+      initialOptions[optionKey] = null;
+    });
+
+    dispatch(actions.optionInit(initialOptions));
+  }, [actions, options]);
+
+  useEffect(() => {
+    const updateTotalPrice = () => {
+      return state.selectedOptions.reduce((total, option) => {
+        if (typeof option.count === 'number') {
+          return total + (price * option.count || 0);
+        }
+        return total;
+      }, 0);
+    };
+    setTotalPrice(updateTotalPrice);
+  }, [price, state.selectedOptions]);
+
   return (
     <div className="px-[20px] md:px-0 my-5">
       {options &&
@@ -182,7 +76,7 @@ const ProductOptions = ({ price, options }: Props) => {
             key={key}
             optionName={key}
             list={value}
-            selectedOption={state.currentOption[key]}
+            selectedOption={state.currentOption[key] as string}
             onClickOption={onClickOption}
           />
         ))}
@@ -217,12 +111,7 @@ const ProductOptions = ({ price, options }: Props) => {
                       <button
                         type="button"
                         className="relative top-[2px] flex items-center justify-center size-4 border-[#a0a0a0] border rounded-full"
-                        onClick={() => {
-                          dispatch({
-                            type: ProductActionType.DELETE_OPTION,
-                            payload: { index },
-                          });
-                        }}
+                        onClick={() => onClickDelete({ index })}
                       >
                         <Icons.DeleteOption />
                       </button>
@@ -235,7 +124,7 @@ const ProductOptions = ({ price, options }: Props) => {
           <div className="flex items-center ml-auto pt-4 pb-2">
             <span className="text-[14px] mr-[10px]">총 상품 금액</span>
             <span className="text-[#ff4800] text-[24px] font-bold">
-              {formatWithCommas(state.totalPrice)}
+              {formatWithCommas(totalPrice)}
             </span>
             <span className="text-[#ff4800]">원</span>
           </div>

--- a/src/store/useProductOptionsReducer.ts
+++ b/src/store/useProductOptionsReducer.ts
@@ -60,7 +60,7 @@ export const productOptionsSlice = createSlice({
         state.selectedOptions = updatedSelectedOptions;
       }
 
-      Object.keys(state.currentOption).map((key) => {
+      Object.keys(state.currentOption).forEach((key) => {
         state.currentOption[key] = null;
       });
     },

--- a/src/store/useProductOptionsReducer.ts
+++ b/src/store/useProductOptionsReducer.ts
@@ -3,30 +3,25 @@ import { ProductOptionType } from '@/types/product';
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
 type initialStateType = {
-  defaultOptions: ProductOptionType;
   currentOption: ProductOptionType;
   selectedOptions: ProductOptionType[];
 };
 
 const initialState: initialStateType = {
-  defaultOptions: {}, // 초기화 ex) {size: null, color: null}
   currentOption: {}, // 현재 선택된 옵션
   selectedOptions: [], // 선택 완료된 옵션들
 };
 
-export const useProductOptionsReducer = createSlice({
+export const productOptionsSlice = createSlice({
   name: 'productOption',
   initialState,
   reducers: {
     optionInit: (state, action: PayloadAction<ProductOptionType>) => {
-      state.defaultOptions = action.payload;
       state.currentOption = action.payload;
     },
     selectOption: (state, action: PayloadAction<PayloadType>) => {
       const { optionType, value } = action.payload;
       if (!optionType || !value) return;
-
-      console.log(action.payload);
 
       // 선택한 옵션에 값 추가
       state.currentOption = {
@@ -51,17 +46,11 @@ export const useProductOptionsReducer = createSlice({
 
       // 동일 옵션으로 선택된게 있다면 수량 추가
       if (existingOptionIndex !== -1) {
-        state.selectedOptions = state.selectedOptions.map(
-          (option: ProductOptionType, index: number) => {
-            if (
-              index === existingOptionIndex &&
-              typeof option.count === 'number'
-            ) {
-              return { ...option, count: option.count + 1 };
-            }
-            return option;
-          },
-        );
+        state.selectedOptions[existingOptionIndex] = {
+          ...state.selectedOptions[existingOptionIndex],
+          count:
+            (state.selectedOptions[existingOptionIndex].count as number) + 1,
+        };
         // 동일 옵션으로 선택된게 없다면 수량 1로 초기화하여 추가
       } else {
         const updatedSelectedOptions = [
@@ -71,17 +60,18 @@ export const useProductOptionsReducer = createSlice({
         state.selectedOptions = updatedSelectedOptions;
       }
 
-      state.currentOption = state.defaultOptions;
+      Object.keys(state.currentOption).map((key) => {
+        state.currentOption[key] = null;
+      });
     },
     changeCount: (state, action: PayloadAction<PayloadType>) => {
-      state.selectedOptions = state.selectedOptions.map(
-        (option: ProductOptionType, index: number) => {
-          if (index === action.payload.index) {
-            return { ...option, count: action.payload.count };
-          }
-          return option;
-        },
-      ) as ProductOptionType[];
+      const { index, count } = action.payload;
+      if (!index || !count) return;
+
+      state.selectedOptions[index] = {
+        ...state.selectedOptions[index],
+        count,
+      };
     },
     deleteOption: (state, action: PayloadAction<PayloadType>) => {
       state.selectedOptions = state.selectedOptions.filter(

--- a/src/store/useProductOptionsReducer.ts
+++ b/src/store/useProductOptionsReducer.ts
@@ -1,0 +1,92 @@
+import { PayloadType } from '@/components/product/productOptions';
+import { ProductOptionType } from '@/types/product';
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+type initialStateType = {
+  defaultOptions: ProductOptionType;
+  currentOption: ProductOptionType;
+  selectedOptions: ProductOptionType[];
+};
+
+const initialState: initialStateType = {
+  defaultOptions: {}, // 초기화 ex) {size: null, color: null}
+  currentOption: {}, // 현재 선택된 옵션
+  selectedOptions: [], // 선택 완료된 옵션들
+};
+
+export const useProductOptionsReducer = createSlice({
+  name: 'productOption',
+  initialState,
+  reducers: {
+    optionInit: (state, action: PayloadAction<ProductOptionType>) => {
+      state.defaultOptions = action.payload;
+      state.currentOption = action.payload;
+    },
+    selectOption: (state, action: PayloadAction<PayloadType>) => {
+      const { optionType, value } = action.payload;
+      if (!optionType || !value) return;
+
+      console.log(action.payload);
+
+      // 선택한 옵션에 값 추가
+      state.currentOption = {
+        ...state.currentOption,
+        [optionType]: value,
+      };
+
+      // 선택해야하는 모든 옵션이 선택되었는지 체크
+      const isOptionComplete = Object.values(state.currentOption).every(
+        (option) => option !== null,
+      );
+      if (!isOptionComplete) return;
+
+      // 이미 동일 옵션으로 선택되어있던게 있는지 확인
+      const existingOptionIndex = state.selectedOptions.findIndex(
+        (option: ProductOptionType) => {
+          return Object.keys(state.currentOption).every(
+            (key) => state.currentOption[key] === option[key],
+          );
+        },
+      );
+
+      // 동일 옵션으로 선택된게 있다면 수량 추가
+      if (existingOptionIndex !== -1) {
+        state.selectedOptions = state.selectedOptions.map(
+          (option: ProductOptionType, index: number) => {
+            if (
+              index === existingOptionIndex &&
+              typeof option.count === 'number'
+            ) {
+              return { ...option, count: option.count + 1 };
+            }
+            return option;
+          },
+        );
+        // 동일 옵션으로 선택된게 없다면 수량 1로 초기화하여 추가
+      } else {
+        const updatedSelectedOptions = [
+          ...state.selectedOptions,
+          { ...state.currentOption, count: 1 },
+        ];
+        state.selectedOptions = updatedSelectedOptions;
+      }
+
+      state.currentOption = state.defaultOptions;
+    },
+    changeCount: (state, action: PayloadAction<PayloadType>) => {
+      state.selectedOptions = state.selectedOptions.map(
+        (option: ProductOptionType, index: number) => {
+          if (index === action.payload.index) {
+            return { ...option, count: action.payload.count };
+          }
+          return option;
+        },
+      ) as ProductOptionType[];
+    },
+    deleteOption: (state, action: PayloadAction<PayloadType>) => {
+      state.selectedOptions = state.selectedOptions.filter(
+        (_, index) => index !== action.payload.index,
+      );
+    },
+  },
+});

--- a/src/types/product.ts
+++ b/src/types/product.ts
@@ -3,7 +3,7 @@ import { OPTION_NAME } from '@/constants/cart';
 export type Options = keyof typeof OPTION_NAME;
 
 export type ProductOptionType = {
-  [key in Options]: string | number | null;
+  [key: string]: string | number | null;
 };
 
 export type ProductDataType = {
@@ -25,7 +25,7 @@ export type ProductDataType = {
       totalSalePrice: number;
     };
     options: {
-      [key in Options]: string[];
+      [key: string]: string[];
     };
   };
   deliveryInfo: {

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,5 +1,7 @@
+import numeral from 'numeral';
+
 export const formatWithCommas = (price: number) => {
-  return price.toLocaleString();
+  return numeral(price).format('0,0');
 };
 
 export const formatLikesToK = (count: number) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -430,6 +430,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@reduxjs/toolkit@npm:^2.3.0":
+  version: 2.3.0
+  resolution: "@reduxjs/toolkit@npm:2.3.0"
+  dependencies:
+    immer: "npm:^10.0.3"
+    redux: "npm:^5.0.1"
+    redux-thunk: "npm:^3.1.0"
+    reselect: "npm:^5.1.0"
+  peerDependencies:
+    react: ^16.9.0 || ^17.0.0 || ^18
+    react-redux: ^7.2.1 || ^8.1.3 || ^9.0.0
+  peerDependenciesMeta:
+    react:
+      optional: true
+    react-redux:
+      optional: true
+  checksum: 10c0/414e90b706331385a2122fc79e33f90c59a9caf9a59419f1bfd7f5e594bc8e4987902fd1bccbc53eb96d22c65ec2981ff5581f3d2df3ecd381a630f391edfc3e
+  languageName: node
+  linkType: hard
+
 "@rtsao/scc@npm:^1.1.0":
   version: 1.1.0
   resolution: "@rtsao/scc@npm:1.1.0"
@@ -1457,6 +1477,7 @@ __metadata:
   resolution: "eqcm@workspace:."
   dependencies:
     "@hookform/resolvers": "npm:^3.9.0"
+    "@reduxjs/toolkit": "npm:^2.3.0"
     "@tanstack/react-query": "npm:^5.56.2"
     "@types/node": "npm:^20"
     "@types/prop-types": "npm:^15"
@@ -2435,7 +2456,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"immer@npm:^10.1.1":
+"immer@npm:^10.0.3, immer@npm:^10.1.1":
   version: 10.1.1
   resolution: "immer@npm:10.1.1"
   checksum: 10c0/b749e10d137ccae91788f41bd57e9387f32ea6d6ea8fd7eb47b23fd7766681575efc7f86ceef7fe24c3bc9d61e38ff5d2f49c2663b2b0c056e280a4510923653
@@ -3932,6 +3953,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"redux-thunk@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "redux-thunk@npm:3.1.0"
+  peerDependencies:
+    redux: ^5.0.0
+  checksum: 10c0/21557f6a30e1b2e3e470933247e51749be7f1d5a9620069a3125778675ce4d178d84bdee3e2a0903427a5c429e3aeec6d4df57897faf93eb83455bc1ef7b66fd
+  languageName: node
+  linkType: hard
+
+"redux@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "redux@npm:5.0.1"
+  checksum: 10c0/b10c28357194f38e7d53b760ed5e64faa317cc63de1fb95bc5d9e127fab956392344368c357b8e7a9bedb0c35b111e7efa522210cfdc3b3c75e5074718e9069c
+  languageName: node
+  linkType: hard
+
 "reflect.getprototypeof@npm:^1.0.4":
   version: 1.0.6
   resolution: "reflect.getprototypeof@npm:1.0.6"
@@ -3977,6 +4014,13 @@ __metadata:
   version: 1.0.0
   resolution: "requires-port@npm:1.0.0"
   checksum: 10c0/b2bfdd09db16c082c4326e573a82c0771daaf7b53b9ce8ad60ea46aa6e30aaf475fe9b164800b89f93b748d2c234d8abff945d2551ba47bf5698e04cd7713267
+  languageName: node
+  linkType: hard
+
+"reselect@npm:^5.1.0":
+  version: 5.1.1
+  resolution: "reselect@npm:5.1.1"
+  checksum: 10c0/219c30da122980f61853db3aebd173524a2accd4b3baec770e3d51941426c87648a125ca08d8c57daa6b8b086f2fdd2703cb035dd6231db98cdbe1176a71f489
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -547,6 +547,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/numeral@npm:^2":
+  version: 2.0.5
+  resolution: "@types/numeral@npm:2.0.5"
+  checksum: 10c0/b18766cc97e79b5c59130ce1d5d5ad8b9287e1efd5ecac402e8a64e45c50aea8c8940c9974358983036d1abbed365a08f7f4d11b8af16874a5d4d0edce9aa4d4
+  languageName: node
+  linkType: hard
+
 "@types/prop-types@npm:*":
   version: 15.7.12
   resolution: "@types/prop-types@npm:15.7.12"
@@ -1480,6 +1487,7 @@ __metadata:
     "@reduxjs/toolkit": "npm:^2.3.0"
     "@tanstack/react-query": "npm:^5.56.2"
     "@types/node": "npm:^20"
+    "@types/numeral": "npm:^2"
     "@types/prop-types": "npm:^15"
     "@types/react": "npm:^18"
     "@types/react-dom": "npm:^18"
@@ -1494,6 +1502,7 @@ __metadata:
     msw: "npm:^2.4.9"
     next: "npm:14.2.9"
     next-auth: "npm:^4.24.7"
+    numeral: "npm:^2.0.6"
     postcss: "npm:^8"
     prettier: "npm:^3.3.3"
     prop-types: "npm:^15.8.1"
@@ -3402,6 +3411,13 @@ __metadata:
   version: 3.0.0
   resolution: "normalize-path@npm:3.0.0"
   checksum: 10c0/e008c8142bcc335b5e38cf0d63cfd39d6cf2d97480af9abdbe9a439221fd4d749763bab492a8ee708ce7a194bb00c9da6d0a115018672310850489137b3da046
+  languageName: node
+  linkType: hard
+
+"numeral@npm:^2.0.6":
+  version: 2.0.6
+  resolution: "numeral@npm:2.0.6"
+  checksum: 10c0/5ed008d3fae05cfa4986b77a85ca10bff29ae6e1fa41a04cce05ea21f08a8a104226f88868930e2a94e3239708d6985d111b5d1291e8b9a3049ffc5365c332d4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 작업 내역
- 상품 옵션 상태 관리를 위해 `useReducer`를 사용한 코드를 `useReducer + RTK` 조합으로 리팩토링
  - RTK의 도입으로 내장된 `immer`를 활용하여 불변성 관리가 용이해졌고, 액션 타입 정의 등 불필요한 보일러플레이트 코드가 감소함
  - 파일을 hook으로 분리하여 컴포넌트의 코드 복잡성을 줄이고, 가독성을 향상시켰습니다. 이로 인해 유지보수가 용이해짐
  
## 참고 자료
- [Using useReducer and Redux Toolkit Together](https://dev.to/sathishskdev/using-usereducer-and-redux-toolkit-together-a-powerful-combination-for-state-management-3b2h)